### PR TITLE
Improve `verify` function API slightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! node_hash=ca6768bb0e267f5c339e639f02101c73be12efd5dd0462959677a86e22bbb58d
 //! node_hash=e8bb977d7ae35a4b7e591ded5e3d7fad0afee0b958d6309a52f48fe46c679c36
 //! ")?;
-//! assert!(verify(&Hash::new(data), &signature, signers, &policy).is_ok());
+//! assert!(verify(&Hash::new(data), &signature, &signers, &policy).is_ok());
 //! # Ok::<(), Box<dyn Error>>(())
 //! ```
 //!

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -34,7 +34,7 @@ macro_rules! bail {
 pub fn verify(
     message: &Hash,
     signature: &SigsumSignature,
-    signers: Vec<PublicKey>,
+    signers: &[PublicKey],
     policy: &Policy,
 ) -> Result {
     let checksum = Hash::new(message);
@@ -53,7 +53,7 @@ fn verify_leaf(
     checksum: &Hash,
     signature: &Signature,
     keyhash: &Hash,
-    signers: Vec<PublicKey>,
+    signers: &[PublicKey],
 ) -> Result {
     for key in signers.iter() {
         if Hash::new(key) == *keyhash {


### PR DESCRIPTION
This makes the `verify` function more idiomatic and a bit easier to use. Take arguments by reference instead of ownership where it makes sense.